### PR TITLE
Update the instructions after osslsigncode update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ dynamic library wasn't used. Maybe the wrong dynamic library?
 
 Get the certificate.pem from your account at Certum.
 
+Note that we can't just use the URI that is given by pkcs11-tool, but need to insert a few '%'s.
+
 Run osslsigncode as follows:
 ```
 osslsigncode sign \
   -pkcs11module $PWD/manager/sc30pkcs11-3.0.6.68-MS.so \
   -certs certificate.pem \
-  -key d7c78f453acfaa35791f0232f351465c6d16ab94 \
+  -key="pkcs11:token=common%20profile;id=%D7%C7%8F%45%3A%CF%AA%35%79%1F%02%32%F3%51%46%5C%6D%16%AB%94;type=private" \
   -pass "$CERT_PIN" \
   -h sha256 \
   -t http://time.certum.pl/ \

--- a/start.sh
+++ b/start.sh
@@ -8,7 +8,7 @@ certum_sh="$script_dir/certum.sh"
 pin_secret="$script_dir/pin.secret"
 pkcs11_so="$script_dir/manager/sc30pkcs11-3.0.6.68-MS.so"
 certificate="$script_dir/certificate.pem"
-key=d7c78f453acfaa35791f0232f351465c6d16ab94
+key=key="pkcs11:token=common%20profile;id=%D7%C7%8F%45%3A%CF%AA%35%79%1F%02%32%F3%51%46%5C%6D%16%AB%94;type=private"
 
 $script_dir/server \
     --verbosity-level=debug \


### PR DESCRIPTION
Starting with osslsigncode 2.10 both the key and certificate must be specified using valid PKCS#11 URIs.

See https://github.com/mtrojnar/osslsigncode/discussions/483